### PR TITLE
Refresh is disabled if closed projects are included #876

### DIFF
--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/WorkspaceAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/WorkspaceAction.java
@@ -369,6 +369,9 @@ public abstract class WorkspaceAction extends SelectionListenerAction {
 		if (!super.updateSelection(selection) || selection.isEmpty()) {
 			return false;
 		}
+		if (getSelectedResources().size() > 1) {
+			return true;
+		}
 		for (IResource r : getSelectedResources()) {
 			if (!r.isAccessible()) {
 				return false;

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ResourceMgmtActionProvider.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ResourceMgmtActionProvider.java
@@ -145,7 +145,8 @@ public class ResourceMgmtActionProvider extends CommonActionProvider {
 			buildAction.selectionChanged(selection);
 			menu.appendToGroup(ICommonMenuConstants.GROUP_BUILD, buildAction);
 		}
-		if (!hasClosedProjects) {
+		// To refresh, even if one project is open
+		if (hasOpenProjects) {
 			refreshAction.selectionChanged(selection);
 			menu.appendToGroup(ICommonMenuConstants.GROUP_BUILD, refreshAction);
 		}


### PR DESCRIPTION
Refreshing all open projects, even if closed projects are included.

Fixes: https://github.com/eclipse-platform/eclipse.platform/issues/876